### PR TITLE
feature: Add Settings > Users page: list, add/edit modal, and delete

### DIFF
--- a/app/Livewire/Settings/Users.php
+++ b/app/Livewire/Settings/Users.php
@@ -2,12 +2,132 @@
 
 namespace App\Livewire\Settings;
 
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
 use Livewire\Component;
+use Spatie\Permission\Models\Role;
 
 class Users extends Component
 {
+    public $users = [];
+
+    public $name;
+    public $email;
+    public $username;
+    public $password;
+    public $role;
+
+    public $user;
+    public $isEdit = false;
+    public $confirmedId;
+
+    protected function rules(): array
+    {
+        $userId = $this->user?->id;
+
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email', 'max:255', 'unique:users,email' . ($userId ? ',' . $userId : '')],
+            'username' => ['required', 'string', 'max:255', 'unique:users,username' . ($userId ? ',' . $userId : '')],
+            'password' => [$this->isEdit ? 'nullable' : 'required', 'string', 'min:6'],
+            'role' => ['nullable', 'string', 'exists:roles,name'],
+        ];
+    }
+
     public function render()
     {
-        return view('livewire.settings.users');
+        $this->users = User::with('roles')->orderBy('id')->get();
+        $roles = Role::orderBy('name')->pluck('name')->all();
+
+        return view('livewire.settings.users', [
+            'roles' => $roles,
+        ]);
+    }
+
+    public function submitUser()
+    {
+        $this->isEdit ? $this->editUser() : $this->addUser();
+    }
+
+    public function addUser()
+    {
+        $this->validate();
+
+        $user = User::create([
+            'name' => $this->name,
+            'email' => $this->email,
+            'username' => $this->username,
+            'password' => Hash::make($this->password),
+        ]);
+
+        if ($this->role) {
+            $user->assignRole($this->role);
+        }
+
+        $this->dispatch('closeModal', elementId: '#userModal');
+        $this->dispatch('toastr', type: 'success', message: __('Going Well!'));
+
+        $this->reset();
+    }
+
+    public function editUser()
+    {
+        $this->validate();
+
+        $this->user->update([
+            'name' => $this->name,
+            'email' => $this->email,
+            'username' => $this->username,
+        ]);
+
+        if ($this->password) {
+            $this->user->update([
+                'password' => Hash::make($this->password),
+            ]);
+        }
+
+        if ($this->role) {
+            $this->user->syncRoles([$this->role]);
+        } else {
+            $this->user->syncRoles([]);
+        }
+
+        $this->dispatch('closeModal', elementId: '#userModal');
+        $this->dispatch('toastr', type: 'success', message: __('Going Well!'));
+
+        $this->reset();
+    }
+
+    public function confirmDeleteUser($id)
+    {
+        $this->confirmedId = $id;
+    }
+
+    public function deleteUser($id)
+    {
+        $user = User::findOrFail($id);
+        $user->delete();
+        $this->dispatch('toastr', type: 'success', message: __('Going Well!'));
+    }
+
+    public function showNewUserModal()
+    {
+        $this->reset();
+    }
+
+    public function showEditUserModal($id)
+    {
+        $user = User::with('roles')->findOrFail($id);
+
+        $this->reset();
+        $this->isEdit = true;
+
+        $this->user = $user;
+        $this->name = $user->name;
+        $this->email = $user->email;
+        $this->username = $user->username;
+        $this->role = $user->roles->pluck('name')->first();
+
+        $this->dispatch('open-user-modal');
     }
 }

--- a/resources/views/_partials/_modals/modal-user.blade.php
+++ b/resources/views/_partials/_modals/modal-user.blade.php
@@ -1,0 +1,46 @@
+<div wire:ignore.self class="modal fade" id="userModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-simple">
+    <div class="modal-content p-0 p-md-5">
+      <div class="modal-body">
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        <div class="text-center mb-4">
+          <h3 class="mb-2">{{ $isEdit ? __('Update User') : __('New User') }}</h3>
+          <p class="text-muted">{{ __('Please fill out the following information') }}</p>
+        </div>
+        <form wire:submit="submitUser" class="row g-3">
+          <div class="col-12">
+            <label class="form-label w-100">{{ __('Name') }}</label>
+            <input wire:model='name' class="form-control @error('name') is-invalid @enderror" type="text" />
+          </div>
+          <div class="col-12">
+            <label class="form-label w-100">{{ __('Email') }}</label>
+            <input wire:model='email' class="form-control @error('email') is-invalid @enderror" type="email" />
+          </div>
+          <div class="col-12">
+            <label class="form-label w-100">{{ __('Username') }}</label>
+            <input wire:model='username' class="form-control @error('username') is-invalid @enderror" type="text" />
+          </div>
+          <div class="col-12">
+            <label class="form-label w-100">{{ __('Password') }}</label>
+            <input wire:model='password' class="form-control @error('password') is-invalid @enderror" type="password"
+              placeholder="{{ $isEdit ? __('Leave blank to keep current password') : '' }}" />
+          </div>
+          <div class="col-12">
+            <label class="form-label w-100">{{ __('Role') }}</label>
+            <select wire:model='role' class="form-select @error('role') is-invalid @enderror">
+              <option value="">{{ __('No role') }}</option>
+              @foreach ($roles as $roleName)
+                <option value="{{ $roleName }}">{{ $roleName }}</option>
+              @endforeach
+            </select>
+          </div>
+
+          <div class="col-12 text-center">
+            <button type="submit" class="btn btn-primary me-sm-3 me-1">{{ __('Submit') }}</button>
+            <button type="reset" class="btn btn-label-secondary btn-reset" data-bs-dismiss="modal" aria-label="Close">{{ __('Cancel') }}</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/resources/views/livewire/settings/users.blade.php
+++ b/resources/views/livewire/settings/users.blade.php
@@ -4,19 +4,97 @@
     $configData = Helper::appClasses();
   @endphp
 
-  @section('title', 'HERE')
+  @section('title', 'Users - Settings')
 
-  @section('vendor-style')
+  <div class="demo-inline-spacing">
+    <button wire:click.prevent='showNewUserModal' type="button" class="btn btn-primary"
+      data-bs-toggle="modal" data-bs-target="#userModal">
+      <span class="ti-xs ti ti-plus me-1"></span>{{ __('Add New User') }}
+    </button>
+  </div>
+  <br>
+  <div class="card">
+    <h5 class="card-header"><i class="ti ti-users ti-lg text-info me-3"></i>{{ __('Users') }}</h5>
+    <div class="table-responsive text-nowrap">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>{{ __('ID') }}</th>
+            <th>{{ __('Name') }}</th>
+            <th>{{ __('Email') }}</th>
+            <th>{{ __('Username') }}</th>
+            <th>{{ __('Roles') }}</th>
+            <th>{{ __('Actions') }}</th>
+          </tr>
+        </thead>
+        <tbody class="table-border-bottom-0">
+          @forelse($users as $user)
+            <tr>
+              <td>{{ $user->id }}</td>
+              <td><strong>{{ $user->name }}</strong></td>
+              <td>{{ $user->email }}</td>
+              <td>{{ $user->username }}</td>
+              <td>{{ $user->getRoleNames()->join(', ') }}</td>
+              <td>
+                <div style="display: flex">
+                  <div class="dropdown">
+                    <button type="button" class="btn p-0 dropdown-toggle hide-arrow" data-bs-toggle="dropdown"><i class="ti ti-dots-vertical"></i></button>
+                    <div class="dropdown-menu">
+                      <a wire:click.prevent='showEditUserModal({{ $user->id }})' data-bs-toggle="modal" data-bs-target="#userModal" class="dropdown-item" href=""><i class="ti ti-pencil me-1"></i>{{ __('Edit') }}</a>
+                      <a wire:click.prevent='confirmDeleteUser({{ $user->id }})' class="dropdown-item" href=""><i class="ti ti-trash me-1"></i>{{ __('Delete') }}</a>
+                    </div>
+                  </div>
+                  @if ($confirmedId === $user->id)
+                    <button wire:click.prevent='deleteUser({{ $user->id }})' type="button" class="btn btn-sm btn-danger waves-effect waves-light">{{ __('Sure?') }}</button>
+                  @endif
+                </div>
+              </td>
+            </tr>
+          @empty
+            <tr>
+              <td colspan="6">
+                <div class="mt-2 mb-2" style="text-align: center">
+                  <h3 class="mb-1 mx-2">{{ __('Oopsie-doodle!') }}</h3>
+                  <p class="mb-4 mx-2">
+                    {{ __('No data found, please sprinkle some data in my virtual bowl, and let the fun begin!') }}
+                  </p>
+                  <button class="btn btn-label-primary mb-4" data-bs-toggle="modal" data-bs-target="#userModal">
+                    {{ __('Add New User') }}
+                  </button>
+                  <div>
+                    <img src="{{ asset('assets/img/illustrations/page-misc-under-maintenance.png') }}" width="200" class="img-fluid">
+                  </div>
+                </div>
+              </td>
+            </tr>
+          @endforelse
+        </tbody>
+      </table>
+    </div>
+  </div>
 
-  @endsection
-
-  @section('page-style')
-
-  @endsection
-
-  {{-- Edit HERE --}}
+  {{-- Modal --}}
+  @include('_partials/_modals/modal-user')
 
   @push('custom-scripts')
-
+    <style>
+      /* Allow dropdown menu to extend outside table when open (avoids clipping Edit/Delete) */
+      .table-responsive.dropdown-open { overflow: visible !important; }
+    </style>
+    <script>
+      $(function () {
+        $(document).on('show.bs.dropdown', function (e) {
+          var $wrap = $(e.target).closest('.table-responsive');
+          if ($wrap.length) $wrap.addClass('dropdown-open');
+        });
+        $(document).on('hide.bs.dropdown', function (e) {
+          var $wrap = $(e.target).closest('.table-responsive');
+          if ($wrap.length) $wrap.removeClass('dropdown-open');
+        });
+      });
+      window.addEventListener('open-user-modal', function () {
+        $('#userModal').modal('show');
+      });
+    </script>
   @endpush
 </div>


### PR DESCRIPTION
## Summary
Adds a full Settings > Users management page so admins can list users, add new users, and edit or delete existing ones. The page follows the same layout and patterns as Structure > Centers (and other structure pages).

## What’s included
- **Users table** – Columns: ID, Name, Email, Username, Roles, Actions (ellipsis menu with Edit and Delete).
- **Add New User** – Button at the top opens a modal with: Name, Email, Username, Password, Role (optional; Spatie).
- **Edit** – Edit in the row menu opens the same modal with the user’s data; password optional (leave blank to keep current).
- **Delete** – Delete in the row menu shows an inline “Sure?” confirmation, then soft-deletes the user.
- **Dropdown visibility** – Table dropdowns no longer get clipped: when a row’s dropdown is open, the table wrapper uses `overflow: visible` so both Edit and Delete are visible (Bootstrap `show.bs.dropdown` / `hide.bs.dropdown` + small script).

## Technical notes
- **Livewire:** `App\Livewire\Settings\Users` – CRUD, validation (unique email/username, password required on create), role assign/sync via Spatie.
- **Views:** `livewire/settings/users.blade.php` (table + “Add New User” button); `_partials/_modals/modal-user.blade.php` (add/edit form).
- **Edit modal:** Opened via browser event `open-user-modal` after `showEditUserModal($id)` runs (same approach as other modal pages).
- **RTL:** Uses the same `me-*` / layout patterns as the rest of the app; no new design patterns.

## How to test
1. Go to **Settings > Users** (Admin only).
2. Use **Add New User** to create a user (set role if desired).
3. Use the ellipsis on a row: **Edit** (modal with pre-filled data), **Delete** (confirm with “Sure?”).
4. Confirm both Edit and Delete are visible in the dropdown for every row.