### PR TITLE
fix: Handle null employee and missing timeline on dashboard

### DIFF
--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -65,7 +65,7 @@
         <div class="card-header">
           <div class="d-flex justify-content-between mb-3">
             <div class="card-title mb-0">
-              <h4 class="card-title mb-1">{{ __('Hi,') }} {{ Employee::find(Auth::user()->employee_id)->first_name }}! 👋</h4>
+              <h4 class="card-title mb-1">{{ __('Hi,') }} {{ $employee?->first_name ?? Auth::user()->name ?? __('there') }}! 👋</h4>
               <small class="text-muted">{{ __('Start your day with a smile') }}</small>
             </div>
             <small class="text-muted">{{ __('ID: ') . Auth::user()->employee_id }}</small>
@@ -193,6 +193,7 @@
                   </div>
                 </div>
               </div> --}}
+              @if($employee)
               <div class="col-md-3 col-6">
                 <div class="d-flex align-items-center">
                   <div class="badge rounded-pill bg-label-warning me-3 p-2"><i class="ti ti-zzz ti-sm"></i></div>
@@ -220,6 +221,7 @@
                   </div>
                 </div>
               </div>
+              @endif
             </div>
           </div>
         @endif


### PR DESCRIPTION
## Summary
Fixes dashboard errors when the authenticated user has no linked employee or no active timeline (e.g. `Call to a member function timelines() on null`, `Attempt to read property "first_name" on null`).

## Changes
- **Dashboard.php (mount):**
  - Resolve `$center` only when the user exists and has an active timeline; avoid calling `timelines()` on null and accessing `->first()->center_id` when `first()` is null.
  - Use empty collections for `activeEmployees` when user or center is missing.
  - Set `employeePhoto` with null-safe access and a default fallback.
- **dashboard.blade.php:**
  - Greeting uses `$employee?->first_name` with fallbacks instead of `Employee::find(...)->first_name`.
  - Employee stats (leave balance, hourly counter, delay counter) wrapped in `@if($employee)` so they are not rendered when there is no employee.

## Result
- No crash when a user has no linked employee or no active timeline.
- Dashboard loads with sensible defaults (e.g. “Hi, there!”, default photo, empty stats) until the account is properly linked.