### PR TITLE
feature: Add Settings > Roles and Permissions pages with CRUD

### DIFF
--- a/app/Livewire/Settings/Permissions.php
+++ b/app/Livewire/Settings/Permissions.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Livewire\Settings;
+
+use Livewire\Component;
+use Spatie\Permission\Models\Permission;
+
+class Permissions extends Component
+{
+    public $permissions = [];
+
+    public $name;
+
+    public $permission;
+    public $isEdit = false;
+    public $confirmedId;
+
+    protected function rules(): array
+    {
+        $except = $this->permission?->id;
+        $nameRule = ['required', 'string', 'max:255'];
+        if ($except) {
+            $nameRule[] = 'unique:permissions,name,' . $except . ',id,guard_name,web';
+        } else {
+            $nameRule[] = 'unique:permissions,name,NULL,id,guard_name,web';
+        }
+
+        return [
+            'name' => $nameRule,
+        ];
+    }
+
+    public function render()
+    {
+        $this->permissions = Permission::where('guard_name', 'web')->orderBy('name')->get();
+
+        return view('livewire.settings.permissions');
+    }
+
+    public function submitPermission()
+    {
+        $this->isEdit ? $this->editPermission() : $this->addPermission();
+    }
+
+    public function addPermission()
+    {
+        $this->validate();
+
+        Permission::create([
+            'name' => $this->name,
+            'guard_name' => 'web',
+        ]);
+
+        $this->dispatch('closeModal', elementId: '#permissionModal');
+        $this->dispatch('toastr', type: 'success', message: __('Going Well!'));
+        $this->reset();
+    }
+
+    public function editPermission()
+    {
+        $this->validate();
+
+        $this->permission->update([
+            'name' => $this->name,
+        ]);
+
+        $this->dispatch('closeModal', elementId: '#permissionModal');
+        $this->dispatch('toastr', type: 'success', message: __('Going Well!'));
+        $this->reset();
+    }
+
+    public function confirmDeletePermission($id)
+    {
+        $this->confirmedId = $id;
+    }
+
+    public function deletePermission($id)
+    {
+        $permission = Permission::findOrFail($id);
+        $permission->delete();
+        $this->dispatch('toastr', type: 'success', message: __('Going Well!'));
+    }
+
+    public function showNewPermissionModal()
+    {
+        $this->reset();
+    }
+
+    public function showEditPermissionModal($id)
+    {
+        $permission = Permission::findOrFail($id);
+
+        $this->reset();
+        $this->isEdit = true;
+        $this->permission = $permission;
+        $this->name = $permission->name;
+
+        $this->dispatch('open-permission-modal');
+    }
+}

--- a/app/Livewire/Settings/Roles.php
+++ b/app/Livewire/Settings/Roles.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Livewire\Settings;
+
+use Livewire\Component;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+class Roles extends Component
+{
+    public $roles = [];
+
+    public $name;
+
+    /** @var array<string> Permission names selected for this role */
+    public $selectedPermissions = [];
+
+    public $role;
+    public $isEdit = false;
+    public $confirmedId;
+
+    protected function rules(): array
+    {
+        $except = $this->role?->id;
+        $nameRule = ['required', 'string', 'max:255'];
+        if ($except) {
+            $nameRule[] = 'unique:roles,name,' . $except . ',id,guard_name,web';
+        } else {
+            $nameRule[] = 'unique:roles,name,NULL,id,guard_name,web';
+        }
+
+        return [
+            'name' => $nameRule,
+        ];
+    }
+
+    public function render()
+    {
+        $this->roles = Role::with('permissions')->orderBy('name')->get();
+        $permissions = Permission::where('guard_name', 'web')->orderBy('name')->get();
+
+        return view('livewire.settings.roles', [
+            'permissions' => $permissions,
+        ]);
+    }
+
+    public function submitRole()
+    {
+        $this->isEdit ? $this->editRole() : $this->addRole();
+    }
+
+    public function addRole()
+    {
+        $this->validate();
+
+        $role = Role::create([
+            'name' => $this->name,
+            'guard_name' => 'web',
+        ]);
+
+        if (! empty($this->selectedPermissions)) {
+            $role->syncPermissions($this->selectedPermissions);
+        }
+
+        $this->dispatch('closeModal', elementId: '#roleModal');
+        $this->dispatch('toastr', type: 'success', message: __('Going Well!'));
+        $this->reset();
+    }
+
+    public function editRole()
+    {
+        $this->validate();
+
+        $this->role->update([
+            'name' => $this->name,
+        ]);
+
+        $this->role->syncPermissions($this->selectedPermissions ?? []);
+
+        $this->dispatch('closeModal', elementId: '#roleModal');
+        $this->dispatch('toastr', type: 'success', message: __('Going Well!'));
+        $this->reset();
+    }
+
+    public function confirmDeleteRole($id)
+    {
+        $this->confirmedId = $id;
+    }
+
+    public function deleteRole($id)
+    {
+        $role = Role::findOrFail($id);
+        $role->delete();
+        $this->dispatch('toastr', type: 'success', message: __('Going Well!'));
+    }
+
+    public function showNewRoleModal()
+    {
+        $this->reset();
+        $this->selectedPermissions = [];
+    }
+
+    public function showEditRoleModal($id)
+    {
+        $role = Role::with('permissions')->findOrFail($id);
+
+        $this->reset();
+        $this->isEdit = true;
+        $this->role = $role;
+        $this->name = $role->name;
+        $this->selectedPermissions = $role->getPermissionNames()->toArray();
+
+        $this->dispatch('open-role-modal');
+    }
+}

--- a/resources/views/_partials/_modals/modal-permission.blade.php
+++ b/resources/views/_partials/_modals/modal-permission.blade.php
@@ -1,0 +1,24 @@
+<div wire:ignore.self class="modal fade" id="permissionModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-simple">
+    <div class="modal-content p-0 p-md-5">
+      <div class="modal-body">
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        <div class="text-center mb-4">
+          <h3 class="mb-2">{{ $isEdit ? __('Update Permission') : __('New Permission') }}</h3>
+          <p class="text-muted">{{ __('Please fill out the following information') }}</p>
+        </div>
+        <form wire:submit="submitPermission" class="row g-3">
+          <div class="col-12">
+            <label class="form-label w-100">{{ __('Name') }}</label>
+            <input wire:model='name' class="form-control @error('name') is-invalid @enderror" type="text" placeholder="{{ __('e.g. view logs') }}" />
+          </div>
+
+          <div class="col-12 text-center">
+            <button type="submit" class="btn btn-primary me-sm-3 me-1">{{ __('Submit') }}</button>
+            <button type="reset" class="btn btn-label-secondary btn-reset" data-bs-dismiss="modal" aria-label="Close">{{ __('Cancel') }}</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/resources/views/_partials/_modals/modal-role.blade.php
+++ b/resources/views/_partials/_modals/modal-role.blade.php
@@ -1,0 +1,37 @@
+<div wire:ignore.self class="modal fade" id="roleModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-simple">
+    <div class="modal-content p-0 p-md-5">
+      <div class="modal-body">
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        <div class="text-center mb-4">
+          <h3 class="mb-2">{{ $isEdit ? __('Update Role') : __('New Role') }}</h3>
+          <p class="text-muted">{{ __('Please fill out the following information') }}</p>
+        </div>
+        <form wire:submit="submitRole" class="row g-3">
+          <div class="col-12">
+            <label class="form-label w-100">{{ __('Name') }}</label>
+            <input wire:model='name' class="form-control @error('name') is-invalid @enderror" type="text" placeholder="{{ __('e.g. Admin') }}" />
+          </div>
+          <div class="col-12">
+            <label class="form-label w-100">{{ __('Permissions') }}</label>
+            <div class="border rounded p-3" style="max-height: 12rem; overflow-y: auto">
+              @forelse($permissions as $permission)
+                <div class="form-check">
+                  <input wire:model="selectedPermissions" class="form-check-input" type="checkbox" value="{{ $permission->name }}" id="perm-{{ $permission->id }}">
+                  <label class="form-check-label" for="perm-{{ $permission->id }}">{{ $permission->name }}</label>
+                </div>
+              @empty
+                <p class="text-muted small mb-0">{{ __('No permissions yet.') }}</p>
+              @endforelse
+            </div>
+          </div>
+
+          <div class="col-12 text-center">
+            <button type="submit" class="btn btn-primary me-sm-3 me-1">{{ __('Submit') }}</button>
+            <button type="reset" class="btn btn-label-secondary btn-reset" data-bs-dismiss="modal" aria-label="Close">{{ __('Cancel') }}</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/resources/views/livewire/settings/permissions.blade.php
+++ b/resources/views/livewire/settings/permissions.blade.php
@@ -1,0 +1,94 @@
+<div>
+
+  @php
+    $configData = Helper::appClasses();
+  @endphp
+
+  @section('title', 'Permissions - Settings')
+
+  <div class="demo-inline-spacing">
+    <button wire:click.prevent='showNewPermissionModal' type="button" class="btn btn-primary"
+      data-bs-toggle="modal" data-bs-target="#permissionModal">
+      <span class="ti-xs ti ti-plus me-1"></span>{{ __('Add New Permission') }}
+    </button>
+  </div>
+  <br>
+  <div class="card">
+    <h5 class="card-header"><i class="ti ti-key ti-lg text-info me-3"></i>{{ __('Permissions') }}</h5>
+    <div class="table-responsive text-nowrap">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>{{ __('ID') }}</th>
+            <th>{{ __('Name') }}</th>
+            <th>{{ __('Actions') }}</th>
+          </tr>
+        </thead>
+        <tbody class="table-border-bottom-0">
+          @forelse($permissions as $permission)
+            <tr>
+              <td>{{ $permission->id }}</td>
+              <td><strong>{{ $permission->name }}</strong></td>
+              <td>
+                <div style="display: flex">
+                  <div class="dropdown">
+                    <button type="button" class="btn p-0 dropdown-toggle hide-arrow" data-bs-toggle="dropdown"><i class="ti ti-dots-vertical"></i></button>
+                    <div class="dropdown-menu">
+                      <a wire:click.prevent='showEditPermissionModal({{ $permission->id }})' data-bs-toggle="modal" data-bs-target="#permissionModal" class="dropdown-item" href=""><i class="ti ti-pencil me-1"></i>{{ __('Edit') }}</a>
+                      <a wire:click.prevent='confirmDeletePermission({{ $permission->id }})' class="dropdown-item" href=""><i class="ti ti-trash me-1"></i>{{ __('Delete') }}</a>
+                    </div>
+                  </div>
+                  @if ($confirmedId === $permission->id)
+                    <button wire:click.prevent='deletePermission({{ $permission->id }})' type="button" class="btn btn-sm btn-danger waves-effect waves-light">{{ __('Sure?') }}</button>
+                  @endif
+                </div>
+              </td>
+            </tr>
+          @empty
+            <tr>
+              <td colspan="3">
+                <div class="mt-2 mb-2" style="text-align: center">
+                  <h3 class="mb-1 mx-2">{{ __('Oopsie-doodle!') }}</h3>
+                  <p class="mb-4 mx-2">
+                    {{ __('No data found, please sprinkle some data in my virtual bowl, and let the fun begin!') }}
+                  </p>
+                  <button class="btn btn-label-primary mb-4" data-bs-toggle="modal" data-bs-target="#permissionModal">
+                    {{ __('Add New Permission') }}
+                  </button>
+                  <div>
+                    <img src="{{ asset('assets/img/illustrations/page-misc-under-maintenance.png') }}" width="200" class="img-fluid">
+                  </div>
+                </div>
+              </td>
+            </tr>
+          @endforelse
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  {{-- Modal --}}
+  @include('_partials/_modals/modal-permission')
+
+  @push('custom-scripts')
+    <style>
+      /* Allow dropdown menu to extend outside table when open (avoids clipping Edit/Delete) */
+      .table-responsive.dropdown-open { overflow: visible !important; }
+    </style>
+    <script>
+      $(function () {
+        $(document).on('show.bs.dropdown', function (e) {
+          var $wrap = $(e.target).closest('.table-responsive');
+          if ($wrap.length) $wrap.addClass('dropdown-open');
+        });
+        $(document).on('hide.bs.dropdown', function (e) {
+          var $wrap = $(e.target).closest('.table-responsive');
+          if ($wrap.length) $wrap.removeClass('dropdown-open');
+        });
+      });
+      window.addEventListener('open-permission-modal', function () {
+        $('#permissionModal').modal('show');
+      });
+    </script>
+  @endpush
+</div>

--- a/resources/views/livewire/settings/roles.blade.php
+++ b/resources/views/livewire/settings/roles.blade.php
@@ -1,0 +1,96 @@
+<div>
+
+  @php
+    $configData = Helper::appClasses();
+  @endphp
+
+  @section('title', 'Roles - Settings')
+
+  <div class="demo-inline-spacing">
+    <button wire:click.prevent='showNewRoleModal' type="button" class="btn btn-primary"
+      data-bs-toggle="modal" data-bs-target="#roleModal">
+      <span class="ti-xs ti ti-plus me-1"></span>{{ __('Add New Role') }}
+    </button>
+  </div>
+  <br>
+  <div class="card">
+    <h5 class="card-header"><i class="ti ti-shield ti-lg text-info me-3"></i>{{ __('Roles') }}</h5>
+    <div class="table-responsive text-nowrap">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>{{ __('ID') }}</th>
+            <th>{{ __('Name') }}</th>
+            <th>{{ __('Permissions') }}</th>
+            <th>{{ __('Actions') }}</th>
+          </tr>
+        </thead>
+        <tbody class="table-border-bottom-0">
+          @forelse($roles as $role)
+            <tr>
+              <td>{{ $role->id }}</td>
+              <td><strong>{{ $role->name }}</strong></td>
+              <td>{{ $role->getPermissionNames()->join(', ') }}</td>
+              <td>
+                <div style="display: flex">
+                  <div class="dropdown">
+                    <button type="button" class="btn p-0 dropdown-toggle hide-arrow" data-bs-toggle="dropdown"><i class="ti ti-dots-vertical"></i></button>
+                    <div class="dropdown-menu">
+                      <a wire:click.prevent='showEditRoleModal({{ $role->id }})' data-bs-toggle="modal" data-bs-target="#roleModal" class="dropdown-item" href=""><i class="ti ti-pencil me-1"></i>{{ __('Edit') }}</a>
+                      <a wire:click.prevent='confirmDeleteRole({{ $role->id }})' class="dropdown-item" href=""><i class="ti ti-trash me-1"></i>{{ __('Delete') }}</a>
+                    </div>
+                  </div>
+                  @if ($confirmedId === $role->id)
+                    <button wire:click.prevent='deleteRole({{ $role->id }})' type="button" class="btn btn-sm btn-danger waves-effect waves-light">{{ __('Sure?') }}</button>
+                  @endif
+                </div>
+              </td>
+            </tr>
+          @empty
+            <tr>
+              <td colspan="4">
+                <div class="mt-2 mb-2" style="text-align: center">
+                  <h3 class="mb-1 mx-2">{{ __('Oopsie-doodle!') }}</h3>
+                  <p class="mb-4 mx-2">
+                    {{ __('No data found, please sprinkle some data in my virtual bowl, and let the fun begin!') }}
+                  </p>
+                  <button class="btn btn-label-primary mb-4" data-bs-toggle="modal" data-bs-target="#roleModal">
+                    {{ __('Add New Role') }}
+                  </button>
+                  <div>
+                    <img src="{{ asset('assets/img/illustrations/page-misc-under-maintenance.png') }}" width="200" class="img-fluid">
+                  </div>
+                </div>
+              </td>
+            </tr>
+          @endforelse
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  {{-- Modal --}}
+  @include('_partials/_modals/modal-role')
+
+  @push('custom-scripts')
+    <style>
+      /* Allow dropdown menu to extend outside table when open (avoids clipping Edit/Delete) */
+      .table-responsive.dropdown-open { overflow: visible !important; }
+    </style>
+    <script>
+      $(function () {
+        $(document).on('show.bs.dropdown', function (e) {
+          var $wrap = $(e.target).closest('.table-responsive');
+          if ($wrap.length) $wrap.addClass('dropdown-open');
+        });
+        $(document).on('hide.bs.dropdown', function (e) {
+          var $wrap = $(e.target).closest('.table-responsive');
+          if ($wrap.length) $wrap.removeClass('dropdown-open');
+        });
+      });
+      window.addEventListener('open-role-modal', function () {
+        $('#roleModal').modal('show');
+      });
+    </script>
+  @endpush
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,8 @@ use App\Livewire\HumanResource\Structure\Employees;
 use App\Livewire\HumanResource\Structure\Positions;
 use App\Livewire\MaintenanceMode;
 use App\Livewire\Misc\ComingSoon;
+use App\Livewire\Settings\Permissions;
+use App\Livewire\Settings\Roles;
 use App\Livewire\Settings\Users;
 use Illuminate\Support\Facades\Route;
 
@@ -91,8 +93,8 @@ Route::middleware([
     Route::group(['middleware' => ['role:Admin']], function () {
         Route::prefix('settings')->group(function () {
             Route::get('/users', Users::class)->name('settings-users');
-            Route::get('/roles', ComingSoon::class)->name('settings-roles');
-            Route::get('/permissions', ComingSoon::class)->name('settings-permissions');
+            Route::get('/roles', Roles::class)->name('settings-roles');
+            Route::get('/permissions', Permissions::class)->name('settings-permissions');
         });
     });
 


### PR DESCRIPTION
## Summary
Adds Settings > Roles and Settings > Permissions management pages so admins can manage Spatie roles and permissions from the UI. Both pages follow the same layout and patterns as Settings > Users (and Structure > Centers).

## What's included

### Roles (`/settings/roles`)
- **Table:** ID, Name, Permissions, Actions (Edit / Delete via dropdown).
- **Add New Role:** Modal with Name and a list of permissions (checkboxes). New roles use guard `web`.
- **Edit:** Same modal; current permissions pre-selected; save syncs permissions for the role.
- **Delete:** Inline “Sure?” confirmation, then delete role (Spatie handles related data).
- Guard is fixed to `web` (no guard field in the UI).

### Permissions (`/settings/permissions`)
- **Table:** ID, Name, Actions (Edit / Delete via dropdown).
- **Add New Permission:** Modal with Name only (guard `web`).
- **Edit / Delete:** Same pattern as Roles.
- Existing “view logs” permission (from `PermissionsSeeder`) appears in the list and can be edited or left as-is.

### Technical
- **Livewire:** `App\Livewire\Settings\Roles`, `App\Livewire\Settings\Permissions`.
- **Views:** `livewire/settings/roles.blade.php`, `livewire/settings/permissions.blade.php`; modals: `modal-role.blade.php`, `modal-permission.blade.php`.
- **Routes:** `settings/roles` and `settings/permissions` now use the new components (replacing ComingSoon); still under `role:Admin`.
- **Dropdowns:** Same table-responsive overflow fix as Users (Bootstrap `show.bs.dropdown` / `hide.bs.dropdown` + `.dropdown-open` CSS) so Edit and Delete are visible in every row.

## How to test
1. As Admin, go to **Settings > Roles** and **Settings > Permissions**.
2. **Roles:** Add a role, assign permissions, edit and delete. Confirm Admin shows its permissions (e.g. “view logs”).
3. **Permissions:** Confirm “view logs” is listed; add another permission, edit name, delete (optional).
4. Confirm row dropdowns show both Edit and Delete on all rows.