### PR TITLE
enhancement: Roles & permissions seeders, protected seeder permissions, and migration fix

### DIFF
--- a/app/Livewire/Dashboard.php
+++ b/app/Livewire/Dashboard.php
@@ -386,7 +386,7 @@ class Dashboard extends Component
         if (
             ! auth()
                 ->user()
-                ->hasAnyRole(['Admin', 'HR', 'CC', 'CR', 'CR-S'])
+                ->hasAnyRole(['Admin', 'HR', 'CC', 'CR'])
         ) {
             abort(403, 'Unauthorized action.');
         }

--- a/config/permission.php
+++ b/config/permission.php
@@ -183,4 +183,17 @@ return [
 
         'store' => 'default',
     ],
+
+    /*
+     * Permission names created by PermissionsSeeder. These cannot be edited or deleted on the settings/permissions page.
+     */
+    'seeded_permission_names' => [
+        'view logs',
+        'create employees',
+        'create fingerprints',
+        'create leaves',
+        'view leaves',
+        'read sms',
+        'import leaves',
+    ],
 ];

--- a/database/migrations/2024_05_27_100007_create_webhook_calls_table.php
+++ b/database/migrations/2024_05_27_100007_create_webhook_calls_table.php
@@ -20,4 +20,9 @@ return new class extends Migration
             $table->timestamps();
         });
     }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('webhook_calls');
+    }
 };

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,7 +5,6 @@ namespace Database\Seeders;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use App\Models\User;
 use Illuminate\Database\Seeder;
-use Spatie\Permission\Models\Role;
 
 class DatabaseSeeder extends Seeder
 {
@@ -32,13 +31,13 @@ class DatabaseSeeder extends Seeder
             ]);
         }
 
-        // Create role
-        $adminRole = Role::firstOrCreate(['name' => 'Admin']);
+        // Create all roles (Admin, AM, CC, CR, HR, Employee, Viewer)
+        $this->call(RolesSeeder::class);
 
-        // Assign role
+        // Assign Admin role to default admin user
         $admin = User::find(1);
         if ($admin) {
-            $admin->assignRole($adminRole);
+            $admin->assignRole('Admin');
         }
 
         $this->call(PermissionsSeeder::class);

--- a/database/seeders/EmployeeUserSeeder.php
+++ b/database/seeders/EmployeeUserSeeder.php
@@ -5,12 +5,11 @@ namespace Database\Seeders;
 use App\Models\Employee;
 use App\Models\User;
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 
 class EmployeeUserSeeder extends Seeder
 {
-    public function run()
+    public function run(): void
     {
         $employees = Employee::where('is_active', 1)
             ->whereDoesntHave('user')
@@ -18,19 +17,15 @@ class EmployeeUserSeeder extends Seeder
 
         foreach ($employees as $employee) {
             $user = User::create([
-                'name' => $employee->first_name.' '.$employee->last_name,
+                'name' => $employee->first_name . ' ' . $employee->last_name,
                 'employee_id' => $employee->id,
                 'username' => $employee->id,
-                'email' => $employee->national_number.'@namaa.sy',
+                'email' => $employee->national_number . '@namaa.sy',
                 'password' => Hash::make($employee->national_number),
-                'profile_photo_path' => 'profile-photos/'.$employee->id.'.jpg',
+                'profile_photo_path' => 'profile-photos/' . $employee->id . '.jpg',
             ]);
 
-            DB::table('model_has_roles')->insert([
-                'role_id' => 7,
-                'model_type' => User::class,
-                'model_id' => $user->id,
-            ]);
+            $user->assignRole('Employee');
         }
 
         $this->command->info("User accounts have been successfully created for {$employees->count()} active employees.");

--- a/database/seeders/PermissionsSeeder.php
+++ b/database/seeders/PermissionsSeeder.php
@@ -8,18 +8,56 @@ use Spatie\Permission\Models\Role;
 
 class PermissionsSeeder extends Seeder
 {
+    private const GUARD = 'web';
+
     /**
-     * Create the "view logs" permission and assign it to the Admin role.
+     * Create all permissions and assign them to roles.
+     * Permission names are read from config so the settings UI can protect them from edit/delete.
      */
     public function run(): void
     {
-        $permission = Permission::firstOrCreate(
-            ['name' => 'view logs', 'guard_name' => 'web']
-        );
+        $permissions = config('permission.seeded_permission_names', []);
 
-        $adminRole = Role::firstWhere('name', 'Admin');
-        if ($adminRole) {
-            $adminRole->givePermissionTo($permission);
+        foreach ($permissions as $name) {
+            Permission::firstOrCreate(
+                ['name' => $name, 'guard_name' => self::GUARD],
+                ['name' => $name, 'guard_name' => self::GUARD]
+            );
+        }
+
+        $allPermissions = collect($permissions);
+
+        $admin = Role::firstWhere('name', 'Admin');
+        if ($admin) {
+            $admin->syncPermissions($allPermissions->toArray());
+        }
+
+        $hr = Role::firstWhere('name', 'HR');
+        if ($hr) {
+            $hr->syncPermissions([
+                'view logs',
+                'create employees',
+                'create fingerprints',
+                'create leaves',
+                'view leaves',
+                'read sms',
+                'import leaves',
+            ]);
+        }
+
+        $cc = Role::firstWhere('name', 'CC');
+        if ($cc) {
+            $cc->syncPermissions([
+                'create leaves',
+                'view leaves',
+                'read sms',
+                'import leaves',
+            ]);
+        }
+
+        $cr = Role::firstWhere('name', 'CR');
+        if ($cr) {
+            $cr->syncPermissions(['view leaves']);
         }
     }
 }

--- a/database/seeders/RolesSeeder.php
+++ b/database/seeders/RolesSeeder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Role;
+
+class RolesSeeder extends Seeder
+{
+    private const GUARD = 'web';
+
+    /** Role names used in routes and menu. */
+    private const ROLES = [
+        'Admin',
+        'AM',
+        'CC',
+        'CR',
+        'HR',
+        'Employee',
+        'Viewer',
+    ];
+
+    /**
+     * Create all application roles with guard_name 'web'.
+     */
+    public function run(): void
+    {
+        foreach (self::ROLES as $name) {
+            Role::firstOrCreate(
+                ['name' => $name, 'guard_name' => self::GUARD],
+                ['name' => $name, 'guard_name' => self::GUARD]
+            );
+        }
+    }
+}

--- a/resources/views/livewire/human-resource/attendance/leaves.blade.php
+++ b/resources/views/livewire/human-resource/attendance/leaves.blade.php
@@ -121,7 +121,7 @@
                       <h6 class="dropdown-header text-uppercase">{{ __('Import & Export') }}</h6>
                     </li>
                     <li>
-                      @can('Import leaves')
+                      @can('import leaves')
                       <button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#importModal">
                         <i class="ti ti-table-import me-1"></i> {{ __('Import From Excel') }}
                       </button>

--- a/resources/views/livewire/settings/permissions.blade.php
+++ b/resources/views/livewire/settings/permissions.blade.php
@@ -34,11 +34,16 @@
                   <div class="dropdown">
                     <button type="button" class="btn p-0 dropdown-toggle hide-arrow" data-bs-toggle="dropdown"><i class="ti ti-dots-vertical"></i></button>
                     <div class="dropdown-menu">
-                      <a wire:click.prevent='showEditPermissionModal({{ $permission->id }})' data-bs-toggle="modal" data-bs-target="#permissionModal" class="dropdown-item" href=""><i class="ti ti-pencil me-1"></i>{{ __('Edit') }}</a>
-                      <a wire:click.prevent='confirmDeletePermission({{ $permission->id }})' class="dropdown-item" href=""><i class="ti ti-trash me-1"></i>{{ __('Delete') }}</a>
+                      @if($this->isSeededPermission($permission))
+                        <span class="dropdown-item text-muted" title="{{ __('Seeded permission') }}"><i class="ti ti-lock me-1"></i>{{ __('Edit') }}</span>
+                        <span class="dropdown-item text-muted" title="{{ __('Seeded permission') }}"><i class="ti ti-lock me-1"></i>{{ __('Delete') }}</span>
+                      @else
+                        <a wire:click.prevent='showEditPermissionModal({{ $permission->id }})' data-bs-toggle="modal" data-bs-target="#permissionModal" class="dropdown-item" href=""><i class="ti ti-pencil me-1"></i>{{ __('Edit') }}</a>
+                        <a wire:click.prevent='confirmDeletePermission({{ $permission->id }})' class="dropdown-item" href=""><i class="ti ti-trash me-1"></i>{{ __('Delete') }}</a>
+                      @endif
                     </div>
                   </div>
-                  @if ($confirmedId === $permission->id)
+                  @if (!$this->isSeededPermission($permission) && $confirmedId === $permission->id)
                     <button wire:click.prevent='deletePermission({{ $permission->id }})' type="button" class="btn btn-sm btn-danger waves-effect waves-light">{{ __('Sure?') }}</button>
                   @endif
                 </div>


### PR DESCRIPTION
## Summary

This PR seeds all roles and permissions used by the app, protects seeder-defined permissions from edit/delete on the settings page, fixes two existing bugs, and adds a missing migration `down()` so `migrate:refresh` works correctly.

## Changes

### Roles and permissions

- **RolesSeeder (new)**  
  Creates all 7 roles used in routes/menu: Admin, AM, CC, CR, HR, Employee, Viewer (`guard_name: web`).

- **PermissionsSeeder (extended)**  
  Creates and assigns all permissions referenced in `@can()` and middleware:  
  `view logs`, `create employees`, `create fingerprints`, `create leaves`, `view leaves`, `read sms`, `import leaves`.  
  Syncs them to Admin (all), HR, CC, and CR as per the existing plan.

- **DatabaseSeeder**  
  Calls RolesSeeder and assigns the Admin role by name instead of creating only the Admin role inline.

- **Config**  
  `config('permission.seeded_permission_names')` is the single source of truth for these permission names; PermissionsSeeder reads from it.

### Settings / Permissions page

- Seeder-defined permissions (those in `seeded_permission_names`) **cannot be edited or deleted** in the UI: Edit/Delete are shown as locked placeholders.
- Custom (non-seeder) permissions remain fully editable and deletable.
- Livewire methods guard edit/delete so direct calls still return an error toast for seeded permissions.

### Bug fixes

- **EmployeeUserSeeder**  
  Uses `$user->assignRole('Employee')` instead of hardcoded `role_id => 7` so it works regardless of role IDs.

- **Dashboard**  
  `authorizeAccess()` uses `'CR'` instead of `'CR-S'` to match routes and menu.

- **Leaves view**  
  Permission name normalized to `import leaves` (lowercase) in the `@can` directive to match the seeded permission.

### Migration

- **webhook_calls**  
  Added `down()` with `Schema::dropIfExists('webhook_calls')` so `php artisan migrate:refresh` rolls back and re-runs cleanly.

## Testing

- Run `php artisan migrate:fresh --seed` (or `migrate:refresh` then `db:seed`) and confirm:
  - All 7 roles and 7 permissions exist; Admin has all permissions; HR/CC/CR have the expected subsets.
  - On **Settings → Permissions**, seeded rows show locked Edit/Delete; new permissions can be added, edited, and deleted.
  - EmployeeUserSeeder (if run) assigns the Employee role by name without errors.