### PR TITLE
enhancement: Employee avatars, Jetstream profile updates, and responsive UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 /public/build
+/build
 /public/hot
 /public/storage
 /storage/*.key

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -147,7 +147,7 @@ return [
         Features::registration(),
         Features::resetPasswords(),
         // Features::emailVerification(),
-        // Features::updateProfileInformation(),
+        Features::updateProfileInformation(),
         Features::updatePasswords(),
         // Features::twoFactorAuthentication([
         //     'confirm' => true,

--- a/resources/views/_partials/_modals/modal-employee.blade.php
+++ b/resources/views/_partials/_modals/modal-employee.blade.php
@@ -22,6 +22,31 @@
           <h3 class="mb-2">{{ $isEdit ? __('Update Employee') : __('New Employee') }}</h3>
           <p class="text-muted">{{ __('Please fill out the following information') }}</p>
         </div>
+        <div class="row mb-4">
+          <div class="col-12 d-flex justify-content-center">
+            <div class="d-flex align-items-center">
+              <div class="me-3">
+                @if ($photo)
+                  <img src="{{ $photo->temporaryUrl() }}" class="rounded-circle" width="80" height="80" alt="Preview">
+                @elseif($isEdit && $this->employee && $this->employee->profile_photo_path)
+                  <img src="{{ Storage::disk('public')->exists($this->employee->profile_photo_path) ? Storage::disk('public')->url($this->employee->profile_photo_path) : '/storage/'.config('app.default_profile_photo_path', 'profile-photos/.default-photo.jpg') }}" class="rounded-circle" width="80" height="80" alt="Avatar">
+                @else
+                  <img src="/storage/{{ config('app.default_profile_photo_path', 'profile-photos/.default-photo.jpg') }}" class="rounded-circle" width="80" height="80" alt="Avatar">
+                @endif
+              </div>
+              <div>
+                <label class="form-label mb-1">{{ __('Avatar') }}</label>
+                <input type="file" wire:model="photo" class="form-control @error('photo') is-invalid @enderror" accept="image/*">
+                @error('photo')
+                  <div class="invalid-feedback">
+                    {{ $message }}
+                  </div>
+                @enderror
+                <small class="text-muted d-block mt-1">{{ __('Allowed types: jpg, jpeg, png. Max size: 1MB') }}</small>
+              </div>
+            </div>
+          </div>
+        </div>
         <form wire:submit="submitEmployee" class="row g-3">
           <div class="col-md-3 col-12 mb-4">
             <label class="form-label">{{ __('ID') }}</label>

--- a/resources/views/livewire/settings/users.blade.php
+++ b/resources/views/livewire/settings/users.blade.php
@@ -20,6 +20,7 @@
         <thead>
           <tr>
             <th>{{ __('ID') }}</th>
+            <th>{{ __('Avatar') }}</th>
             <th>{{ __('Name') }}</th>
             <th>{{ __('Email') }}</th>
             <th>{{ __('Username') }}</th>
@@ -31,6 +32,9 @@
           @forelse($users as $user)
             <tr>
               <td>{{ $user->id }}</td>
+              <td>
+                <img src="{{ $user->profile_photo_url }}" alt="" class="rounded-circle" width="32" height="32">
+              </td>
               <td><strong>{{ $user->name }}</strong></td>
               <td>{{ $user->email }}</td>
               <td>{{ $user->username }}</td>
@@ -52,7 +56,7 @@
             </tr>
           @empty
             <tr>
-              <td colspan="6">
+              <td colspan="7">
                 <div class="mt-2 mb-2" style="text-align: center">
                   <h3 class="mb-1 mx-2">{{ __('Oopsie-doodle!') }}</h3>
                   <p class="mb-4 mx-2">

--- a/tests/Feature/LivewireEmployeesTest.php
+++ b/tests/Feature/LivewireEmployeesTest.php
@@ -1,0 +1,269 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Contract;
+use App\Models\Employee;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class LivewireEmployeesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+    }
+
+    protected function admin(): User
+    {
+        $user = User::factory()->create();
+        $user->assignRole('Admin');
+
+        return $user;
+    }
+
+    /** @return array<string, mixed> */
+    protected function validEmployeeInfo(int $id = 88888): array
+    {
+        $contract = Contract::factory()->create();
+
+        return [
+            'id' => $id,
+            'contractId' => $contract->id,
+            'firstName' => 'Test',
+            'fatherName' => 'Father',
+            'lastName' => 'Employee',
+            'motherName' => 'Mother',
+            'birthAndPlace' => 'Damascus, Syria',
+            'nationalNumber' => '02000000000',
+            'mobileNumber' => '900000001',
+            'degree' => 'Bachelor',
+            'gender' => 1,
+            'address' => '123 Test St',
+            'notes' => null,
+        ];
+    }
+
+    public function test_employees_component_renders(): void
+    {
+        $this->actingAs($this->admin());
+
+        Livewire::test(\App\Livewire\HumanResource\Structure\Employees::class)
+            ->assertStatus(200);
+    }
+
+    public function test_structure_employees_page_contains_avatar_and_name_columns(): void
+    {
+        $this->actingAs($this->admin());
+
+        $response = $this->get(route('structure-employees'));
+
+        $response->assertStatus(200);
+        $response->assertSee(__('Avatar'), false);
+        $response->assertSee(__('Name'), false);
+        $response->assertSee('ti-dots-vertical', false);
+    }
+
+    public function test_can_add_employee_without_photo(): void
+    {
+        $this->actingAs($this->admin());
+        $info = $this->validEmployeeInfo(88881);
+
+        Livewire::test(\App\Livewire\HumanResource\Structure\Employees::class)
+            ->set('employeeInfo.id', $info['id'])
+            ->set('employeeInfo.contractId', $info['contractId'])
+            ->set('employeeInfo.firstName', $info['firstName'])
+            ->set('employeeInfo.fatherName', $info['fatherName'])
+            ->set('employeeInfo.lastName', $info['lastName'])
+            ->set('employeeInfo.motherName', $info['motherName'])
+            ->set('employeeInfo.birthAndPlace', $info['birthAndPlace'])
+            ->set('employeeInfo.nationalNumber', $info['nationalNumber'])
+            ->set('employeeInfo.mobileNumber', $info['mobileNumber'])
+            ->set('employeeInfo.degree', $info['degree'])
+            ->set('employeeInfo.gender', $info['gender'])
+            ->set('employeeInfo.address', $info['address'])
+            ->set('employeeInfo.notes', $info['notes'])
+            ->call('submitEmployee')
+            ->assertRedirect(route('structure-employees-info', ['id' => $info['id']]));
+
+        $this->assertDatabaseHas('employees', [
+            'id' => $info['id'],
+            'first_name' => 'Test',
+            'last_name' => 'Employee',
+        ]);
+        $employee = Employee::find($info['id']);
+        $this->assertNotNull($employee);
+        $defaultPath = config('app.default_profile_photo_path', 'profile-photos/.default-photo.jpg');
+        $this->assertSame($defaultPath, $employee->profile_photo_path);
+    }
+
+    public function test_can_add_employee_with_photo(): void
+    {
+        Storage::fake('public');
+        $this->actingAs($this->admin());
+        $info = $this->validEmployeeInfo(88882);
+        $file = UploadedFile::fake()->image('avatar.jpg', 100, 100);
+
+        Livewire::test(\App\Livewire\HumanResource\Structure\Employees::class)
+            ->set('employeeInfo.id', $info['id'])
+            ->set('employeeInfo.contractId', $info['contractId'])
+            ->set('employeeInfo.firstName', $info['firstName'])
+            ->set('employeeInfo.fatherName', $info['fatherName'])
+            ->set('employeeInfo.lastName', $info['lastName'])
+            ->set('employeeInfo.motherName', $info['motherName'])
+            ->set('employeeInfo.birthAndPlace', $info['birthAndPlace'])
+            ->set('employeeInfo.nationalNumber', $info['nationalNumber'])
+            ->set('employeeInfo.mobileNumber', $info['mobileNumber'])
+            ->set('employeeInfo.degree', $info['degree'])
+            ->set('employeeInfo.gender', $info['gender'])
+            ->set('employeeInfo.address', $info['address'])
+            ->set('employeeInfo.notes', $info['notes'])
+            ->set('photo', $file)
+            ->call('submitEmployee')
+            ->assertRedirect(route('structure-employees-info', ['id' => $info['id']]));
+
+        $employee = Employee::find($info['id']);
+        $this->assertNotNull($employee);
+        $this->assertStringStartsWith('profile-photos/', $employee->profile_photo_path);
+        $this->assertTrue(Storage::disk('public')->exists($employee->profile_photo_path));
+    }
+
+    public function test_add_employee_validation_requires_required_fields(): void
+    {
+        $this->actingAs($this->admin());
+
+        Livewire::test(\App\Livewire\HumanResource\Structure\Employees::class)
+            ->set('employeeInfo.id', 88883)
+            ->set('employeeInfo.contractId', Contract::factory()->create()->id)
+            ->set('employeeInfo.firstName', '')
+            ->set('employeeInfo.fatherName', 'F')
+            ->set('employeeInfo.lastName', 'L')
+            ->set('employeeInfo.motherName', 'M')
+            ->set('employeeInfo.birthAndPlace', 'Place')
+            ->set('employeeInfo.nationalNumber', '02000000001')
+            ->set('employeeInfo.mobileNumber', '900000002')
+            ->set('employeeInfo.degree', 'Bachelor')
+            ->set('employeeInfo.gender', 1)
+            ->set('employeeInfo.address', 'Address')
+            ->call('submitEmployee')
+            ->assertHasErrors(['employeeInfo.firstName']);
+    }
+
+    public function test_can_edit_employee_without_photo(): void
+    {
+        $this->actingAs($this->admin());
+        $employee = Employee::factory()->create([
+            'first_name' => 'Original',
+            'last_name' => 'Name',
+            'national_number' => '02000000011',
+            'mobile_number' => '900000011',
+            'profile_photo_path' => config('app.default_profile_photo_path', 'profile-photos/.default-photo.jpg'),
+        ]);
+
+        $component = Livewire::test(\App\Livewire\HumanResource\Structure\Employees::class)
+            ->call('showEditEmployeeModal', $employee);
+
+        $info = $component->get('employeeInfo');
+        $info['firstName'] = 'Updated';
+        $info['lastName'] = 'Surname';
+
+        $component->set('employeeInfo', $info)->call('submitEmployee');
+
+        $employee->refresh();
+        $this->assertSame('Updated', $employee->first_name);
+        $this->assertSame('Surname', $employee->last_name);
+    }
+
+    public function test_can_edit_employee_with_photo(): void
+    {
+        Storage::fake('public');
+        $this->actingAs($this->admin());
+        $employee = Employee::factory()->create([
+            'national_number' => '02000000012',
+            'mobile_number' => '900000012',
+            'profile_photo_path' => config('app.default_profile_photo_path', 'profile-photos/.default-photo.jpg'),
+        ]);
+        $file = UploadedFile::fake()->image('new-avatar.jpg', 100, 100);
+
+        Livewire::test(\App\Livewire\HumanResource\Structure\Employees::class)
+            ->call('showEditEmployeeModal', $employee)
+            ->set('photo', $file)
+            ->call('submitEmployee');
+
+        $employee->refresh();
+        $this->assertStringStartsWith('profile-photos/', $employee->profile_photo_path);
+        $this->assertTrue(Storage::disk('public')->exists($employee->profile_photo_path));
+    }
+
+    public function test_can_delete_employee(): void
+    {
+        $this->actingAs($this->admin());
+        $employee = Employee::factory()->create(['first_name' => 'To Delete']);
+
+        Livewire::test(\App\Livewire\HumanResource\Structure\Employees::class)
+            ->call('deleteEmployee', $employee);
+
+        $this->assertSoftDeleted('employees', ['id' => $employee->id]);
+    }
+
+    public function test_show_create_modal_resets_state(): void
+    {
+        $this->actingAs($this->admin());
+        $employee = Employee::factory()->create();
+
+        $component = Livewire::test(\App\Livewire\HumanResource\Structure\Employees::class)
+            ->call('showEditEmployeeModal', $employee)
+            ->call('showCreateEmployeeModal');
+
+        $this->assertFalse($component->get('isEdit'));
+        $this->assertEmpty($component->get('employeeInfo'));
+    }
+
+    public function test_show_edit_modal_populates_employee_info(): void
+    {
+        $this->actingAs($this->admin());
+        $employee = Employee::factory()->create([
+            'first_name' => 'Edit',
+            'last_name' => 'Me',
+        ]);
+
+        $component = Livewire::test(\App\Livewire\HumanResource\Structure\Employees::class)
+            ->call('showEditEmployeeModal', $employee);
+
+        $this->assertTrue($component->get('isEdit'));
+        $this->assertSame($employee->id, $component->get('employeeInfo')['id']);
+        $this->assertSame('Edit', $component->get('employeeInfo')['firstName']);
+        $this->assertSame('Me', $component->get('employeeInfo')['lastName']);
+    }
+
+    public function test_photo_validation_rejects_oversized_image(): void
+    {
+        $this->actingAs($this->admin());
+        $info = $this->validEmployeeInfo(88884);
+        // Create an image larger than 1024 KB (1 MB) to fail max:1024 validation
+        $file = UploadedFile::fake()->image('large.jpg', 1200, 1200)->size(2048);
+
+        Livewire::test(\App\Livewire\HumanResource\Structure\Employees::class)
+            ->set('employeeInfo.id', $info['id'])
+            ->set('employeeInfo.contractId', $info['contractId'])
+            ->set('employeeInfo.firstName', $info['firstName'])
+            ->set('employeeInfo.fatherName', $info['fatherName'])
+            ->set('employeeInfo.lastName', $info['lastName'])
+            ->set('employeeInfo.motherName', $info['motherName'])
+            ->set('employeeInfo.birthAndPlace', $info['birthAndPlace'])
+            ->set('employeeInfo.nationalNumber', $info['nationalNumber'])
+            ->set('employeeInfo.mobileNumber', $info['mobileNumber'])
+            ->set('employeeInfo.degree', $info['degree'])
+            ->set('employeeInfo.gender', $info['gender'])
+            ->set('employeeInfo.address', $info['address'])
+            ->set('employeeInfo.notes', $info['notes'])
+            ->set('photo', $file)
+            ->call('submitEmployee')
+            ->assertHasErrors(['photo']);
+    }
+}

--- a/tests/Feature/LivewireUsersSettingsTest.php
+++ b/tests/Feature/LivewireUsersSettingsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class LivewireUsersSettingsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+    }
+
+    protected function admin(): User
+    {
+        $user = User::factory()->create();
+        $user->assignRole('Admin');
+
+        return $user;
+    }
+
+    public function test_users_component_renders(): void
+    {
+        $this->actingAs($this->admin());
+
+        Livewire::test(\App\Livewire\Settings\Users::class)
+            ->assertStatus(200);
+    }
+
+    public function test_settings_users_page_contains_avatar_column(): void
+    {
+        $this->actingAs($this->admin());
+
+        $response = $this->get(route('settings-users'));
+
+        $response->assertStatus(200);
+        $response->assertSee(__('Avatar'), false);
+        $response->assertSee(__('ID'), false);
+        $response->assertSee(__('Name'), false);
+    }
+}

--- a/tests/Unit/Models/EmployeeTest.php
+++ b/tests/Unit/Models/EmployeeTest.php
@@ -101,4 +101,35 @@ class EmployeeTest extends TestCase
         $employee->setRawAttributes(['delay_counter' => null]);
         $this->assertSame('', $employee->delay_counter);
     }
+
+    public function test_get_employee_photo_returns_user_photo_when_user_linked(): void
+    {
+        $employee = Employee::factory()->create();
+        $user = \App\Models\User::factory()->create([
+            'employee_id' => $employee->id,
+            'profile_photo_path' => 'profile-photos/custom.jpg',
+        ]);
+
+        $photo = $employee->getEmployeePhoto();
+
+        $this->assertSame('storage/profile-photos/custom.jpg', $photo);
+    }
+
+    public function test_get_employee_photo_returns_default_when_no_user_linked(): void
+    {
+        $employee = Employee::factory()->create();
+
+        $photo = $employee->getEmployeePhoto();
+
+        $defaultPath = config('app.default_profile_photo_path', 'profile-photos/.default-photo.jpg');
+        $this->assertSame('storage/' . $defaultPath, $photo);
+    }
+
+    public function test_profile_photo_path_is_fillable(): void
+    {
+        $path = 'profile-photos/test.jpg';
+        $employee = Employee::factory()->create(['profile_photo_path' => $path]);
+
+        $this->assertSame($path, $employee->profile_photo_path);
+    }
 }


### PR DESCRIPTION
## Summary

Adds employee avatar support, re-enables Jetstream profile updates, and improves the structure/employees and settings/users pages (layout, actions, and Avatar column).

## Changes

### Profile & avatars
- **Jetstream profile updates** – Enable Fortify `Features::updateProfileInformation()` so users can update name, email, and profile photo from the Profile page.
- **Employee avatars** – New/Edit employee modals support optional avatar upload; files are stored on the `public` disk under `profile-photos/` and saved to `employees.profile_photo_path`.
- **Avatar column** – Dedicated Avatar column between ID and Name on `/structure/employees`; Avatar column after ID on `/settings/users`.

### Structure / Employees UI
- **Actions** – Replace pencil/trash icon buttons with an ellipses dropdown (`ti-dots-vertical`) matching `/structure/centers` (Edit, Delete; “Sure?” for delete confirmation).
- **Layout** – Card header uses flex-wrap so title and search stack on small screens; table no longer uses fixed column widths; Name column has `max-width: 20rem` and truncation so long names don’t overflow into Mobile.
- **Dropdown overflow** – Script + `.table-responsive.dropdown-open` so the actions dropdown isn’t clipped on small viewports.
- **Avatar display** – Employee avatars use `Storage::disk('public')->exists()` and fall back to the default profile photo when missing.

### Tests
- **LivewireEmployeesTest** – Component render; page contains Avatar/Name/ellipses; add employee with/without photo; edit with/without photo; validation (required fields, oversized image); delete; create/edit modal state.
- **LivewireUsersSettingsTest** – Users component render; settings/users page contains Avatar column.
- **EmployeeTest (unit)** – `getEmployeePhoto` (with/without linked user), `profile_photo_path` fillable.

## Testing

- `php artisan test tests/Feature/LivewireEmployeesTest.php tests/Feature/LivewireUsersSettingsTest.php tests/Unit/Models/EmployeeTest.php`